### PR TITLE
Wrap driver dashboards in scroll views and shrink-wrap lists

### DIFF
--- a/sxui/lib/app/Widgits/Drivers/driver1.dart
+++ b/sxui/lib/app/Widgits/Drivers/driver1.dart
@@ -296,26 +296,27 @@ class _BoxX6State extends State<BoxX6> {
     final int totalPickups = _pickupItems.length;
     final int totalDeliveries = _deliveryItems.length;
 
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      decoration: BoxDecoration(
-        color: Colors.grey[700],
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.grey[800]!, width: 1),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(
-            child: Text(
-              'Driver1',
-              style: titleStyle,
-              textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.grey[700],
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.grey[800]!, width: 1),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                'Driver1',
+                style: titleStyle,
+                textAlign: TextAlign.center,
+              ),
             ),
-          ),
-          const SizedBox(height: 12),
-          Expanded(
-            child: Row(
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Expanded(
                   child: Column(
@@ -327,22 +328,22 @@ class _BoxX6State extends State<BoxX6> {
                         child: Text('Pickup', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _pickupItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _pickupItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildPickupItem(
-                                        _pickupItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No pickups available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _pickupItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _pickupItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildPickupItem(
+                                      _pickupItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No pickups available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(child: Text('$totalPickups', style: titleStyle)),
@@ -351,7 +352,6 @@ class _BoxX6State extends State<BoxX6> {
                 ),
                 Container(
                   width: 1,
-                  height: double.infinity,
                   color: Colors.grey[800],
                   margin: const EdgeInsets.symmetric(horizontal: 8.0),
                 ),
@@ -365,22 +365,22 @@ class _BoxX6State extends State<BoxX6> {
                         child: Text('Delivery', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _deliveryItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _deliveryItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildDeliveryItem(
-                                        _deliveryItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No deliveries available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _deliveryItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _deliveryItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildDeliveryItem(
+                                      _deliveryItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No deliveries available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(
@@ -390,8 +390,8 @@ class _BoxX6State extends State<BoxX6> {
                 ),
               ],
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/sxui/lib/app/Widgits/Drivers/driver2.dart
+++ b/sxui/lib/app/Widgits/Drivers/driver2.dart
@@ -306,26 +306,27 @@ class _BoxX7State extends State<BoxX7> {
     final int totalPickups = _pickupItems.length;
     final int totalDeliveries = _deliveryItems.length;
 
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      decoration: BoxDecoration(
-        color: Colors.grey[700],
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.grey[800]!, width: 1),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(
-            child: Text(
-              'Driver2',
-              style: titleStyle,
-              textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.grey[700],
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.grey[800]!, width: 1),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                'Driver2',
+                style: titleStyle,
+                textAlign: TextAlign.center,
+              ),
             ),
-          ),
-          const SizedBox(height: 12),
-          Expanded(
-            child: Row(
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Expanded(
                   child: Column(
@@ -337,22 +338,22 @@ class _BoxX7State extends State<BoxX7> {
                         child: Text('Pickup', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _pickupItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _pickupItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildPickupItem(
-                                        _pickupItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No pickups available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _pickupItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _pickupItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildPickupItem(
+                                      _pickupItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No pickups available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(child: Text('$totalPickups', style: titleStyle)),
@@ -361,7 +362,6 @@ class _BoxX7State extends State<BoxX7> {
                 ),
                 Container(
                   width: 1,
-                  height: double.infinity,
                   color: Colors.grey[800],
                   margin: const EdgeInsets.symmetric(horizontal: 8.0),
                 ),
@@ -375,22 +375,22 @@ class _BoxX7State extends State<BoxX7> {
                         child: Text('Delivery', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _deliveryItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _deliveryItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildDeliveryItem(
-                                        _deliveryItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No deliveries available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _deliveryItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _deliveryItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildDeliveryItem(
+                                      _deliveryItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No deliveries available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(
@@ -400,8 +400,8 @@ class _BoxX7State extends State<BoxX7> {
                 ),
               ],
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/sxui/lib/app/Widgits/Drivers/driver3.dart
+++ b/sxui/lib/app/Widgits/Drivers/driver3.dart
@@ -306,26 +306,27 @@ class _BoxX8State extends State<BoxX8> {
     final int totalPickups = _pickupItems.length;
     final int totalDeliveries = _deliveryItems.length;
 
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      decoration: BoxDecoration(
-        color: Colors.grey[700],
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.grey[800]!, width: 1),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(
-            child: Text(
-              'Driver3',
-              style: titleStyle,
-              textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.grey[700],
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.grey[800]!, width: 1),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                'Driver3',
+                style: titleStyle,
+                textAlign: TextAlign.center,
+              ),
             ),
-          ),
-          const SizedBox(height: 12),
-          Expanded(
-            child: Row(
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Expanded(
                   child: Column(
@@ -337,22 +338,22 @@ class _BoxX8State extends State<BoxX8> {
                         child: Text('Pickup', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _pickupItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _pickupItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildPickupItem(
-                                        _pickupItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No pickups available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _pickupItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _pickupItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildPickupItem(
+                                      _pickupItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No pickups available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(child: Text('$totalPickups', style: titleStyle)),
@@ -361,7 +362,6 @@ class _BoxX8State extends State<BoxX8> {
                 ),
                 Container(
                   width: 1,
-                  height: double.infinity,
                   color: Colors.grey[800],
                   margin: const EdgeInsets.symmetric(horizontal: 8.0),
                 ),
@@ -375,22 +375,22 @@ class _BoxX8State extends State<BoxX8> {
                         child: Text('Delivery', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _deliveryItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _deliveryItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildDeliveryItem(
-                                        _deliveryItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No deliveries available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _deliveryItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _deliveryItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildDeliveryItem(
+                                      _deliveryItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No deliveries available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(
@@ -400,8 +400,8 @@ class _BoxX8State extends State<BoxX8> {
                 ),
               ],
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/sxui/lib/app/Widgits/Drivers/driver4.dart
+++ b/sxui/lib/app/Widgits/Drivers/driver4.dart
@@ -333,26 +333,27 @@ class _BoxX9State extends State<BoxX9> {
     final int totalPickups = _pickupItems.length;
     final int totalDeliveries = _deliveryItems.length;
 
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      decoration: BoxDecoration(
-        color: Colors.grey[700],
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.grey[800]!, width: 1),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(
-            child: Text(
-              'Driver1',
-              style: titleStyle,
-              textAlign: TextAlign.center,
+    return SingleChildScrollView(
+      child: Container(
+        padding: const EdgeInsets.all(16.0),
+        decoration: BoxDecoration(
+          color: Colors.grey[700],
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: Colors.grey[800]!, width: 1),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Text(
+                'Driver1',
+                style: titleStyle,
+                textAlign: TextAlign.center,
+              ),
             ),
-          ),
-          const SizedBox(height: 12),
-          Expanded(
-            child: Row(
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Expanded(
                   child: Column(
@@ -364,22 +365,22 @@ class _BoxX9State extends State<BoxX9> {
                         child: Text('Pickup', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _pickupItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _pickupItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildPickupItem(
-                                        _pickupItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No pickups available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _pickupItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _pickupItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildPickupItem(
+                                      _pickupItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No pickups available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(child: Text('$totalPickups', style: titleStyle)),
@@ -388,7 +389,6 @@ class _BoxX9State extends State<BoxX9> {
                 ),
                 Container(
                   width: 1,
-                  height: double.infinity,
                   color: Colors.grey[800],
                   margin: const EdgeInsets.symmetric(horizontal: 8.0),
                 ),
@@ -402,22 +402,22 @@ class _BoxX9State extends State<BoxX9> {
                         child: Text('Delivery', style: subtitleStyle),
                       ),
                       const SizedBox(height: 8),
-                      Expanded(
-                        child: ScrollConfiguration(
-                          behavior: NoGlowScrollBehavior(),
-                          child: _deliveryItems.isNotEmpty
-                              ? ListView.builder(
-                                  itemCount: _deliveryItems.length,
-                                  itemBuilder: (context, index) {
-                                    return _buildDeliveryItem(
-                                        _deliveryItems[index]);
-                                  },
-                                )
-                              : Center(
-                                  child: Text('No deliveries available',
-                                      style: itemStyle),
-                                ),
-                        ),
+                      ScrollConfiguration(
+                        behavior: NoGlowScrollBehavior(),
+                        child: _deliveryItems.isNotEmpty
+                            ? ListView.builder(
+                                shrinkWrap: true,
+                                physics: const NeverScrollableScrollPhysics(),
+                                itemCount: _deliveryItems.length,
+                                itemBuilder: (context, index) {
+                                  return _buildDeliveryItem(
+                                      _deliveryItems[index]);
+                                },
+                              )
+                            : Center(
+                                child: Text('No deliveries available',
+                                    style: itemStyle),
+                              ),
                       ),
                       const SizedBox(height: 8),
                       Center(
@@ -427,8 +427,8 @@ class _BoxX9State extends State<BoxX9> {
                 ),
               ],
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- prevent overflow by wrapping driver widgets in `SingleChildScrollView`
- convert internal lists to shrink-wrapped, non-scrollable builders

## Testing
- `dart format lib/app/Widgits/Drivers/driver1.dart lib/app/Widgits/Drivers/driver2.dart lib/app/Widgits/Drivers/driver3.dart lib/app/Widgits/Drivers/driver4.dart` *(command not found)*
- `flutter format lib/app/Widgits/Drivers/driver1.dart lib/app/Widgits/Drivers/driver2.dart lib/app/Widgits/Drivers/driver3.dart lib/app/Widgits/Drivers/driver4.dart` *(command not found)*
- `apt-get update` *(403: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68993d79738c832fbb83b4dde9ac8140