### PR TITLE
feat: support tile overflow scrolling

### DIFF
--- a/sxui/lib/app/ui.dart
+++ b/sxui/lib/app/ui.dart
@@ -716,7 +716,6 @@ class _TileChrome extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 300),
-        height: height,
         decoration: BoxDecoration(
           gradient: const LinearGradient(
             colors: [Color(0xFF0B0F1A), Color(0xFF111827)],
@@ -731,7 +730,13 @@ class _TileChrome extends StatelessWidget {
             BoxShadow(color: accent.withOpacity(0.15), blurRadius: 20, spreadRadius: 1),
           ],
         ),
-        child: Material(color: Colors.transparent, child: child),
+        child: Material(
+          color: Colors.transparent,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: height),
+            child: SingleChildScrollView(child: child),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- allow `_TileChrome` to expand beyond its predicted height using `ConstrainedBox`
- enable scrolling for tile content with `SingleChildScrollView`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68993d745a60832f9518055e7eb87107